### PR TITLE
refactor: MenuGenerator를 인터페이스로 변경 후 세부 클래스로 분리

### DIFF
--- a/HolubLife/src/com/holub/life/Life.java
+++ b/HolubLife/src/com/holub/life/Life.java
@@ -1,6 +1,6 @@
 package com.holub.life;
 
-import com.holub.ui.MenuGenerator;
+import com.holub.ui.MenuBuilder;
 import com.holub.ui.MenuSite;
 
 import javax.swing.*;
@@ -26,7 +26,7 @@ public final class Life extends JFrame {
         // Must establish the MenuSite very early in case
         // a subcomponent puts menus on it.
         MenuSite.establish(this);        //{=life.java.establish}
-        MenuGenerator.generate();
+        MenuBuilder.generate(new Object());
 
         setDefaultCloseOperation(EXIT_ON_CLOSE);
         getContentPane().setLayout(new BorderLayout());

--- a/HolubLife/src/com/holub/life/Life.java
+++ b/HolubLife/src/com/holub/life/Life.java
@@ -26,7 +26,7 @@ public final class Life extends JFrame {
         // Must establish the MenuSite very early in case
         // a subcomponent puts menus on it.
         MenuSite.establish(this);        //{=life.java.establish}
-        MenuBuilder.generate(new Object());
+        MenuBuilder.generate(this);
 
         setDefaultCloseOperation(EXIT_ON_CLOSE);
         getContentPane().setLayout(new BorderLayout());

--- a/HolubLife/src/com/holub/ui/GoMenuGenerator.java
+++ b/HolubLife/src/com/holub/ui/GoMenuGenerator.java
@@ -1,0 +1,27 @@
+package com.holub.ui;
+
+import com.holub.constant.Modifier;
+import com.holub.life.Clock;
+
+public class GoMenuGenerator implements MenuGenerator{
+    public void generate(Object requester){
+        MenuSite.addLine(requester, "Go", "Tick", e -> {
+            Clock.instance().tick();
+        });
+        MenuSite.addLine(requester, "Go", "Hart", e -> {
+            Clock.instance().stop();
+        });
+        MenuSite.addLine(requester, "Go", "Agonizing", e -> {
+            Clock.instance().startTicking(Modifier.AGONIZING);
+        });
+        MenuSite.addLine(requester, "Go", "Slow", e -> {
+            Clock.instance().startTicking(Modifier.SLOW);
+        });
+        MenuSite.addLine(requester, "Go", "Medium", e -> {
+            Clock.instance().startTicking(Modifier.MEDIUM);
+        });
+        MenuSite.addLine(requester, "Go", "Fast", e -> {
+            Clock.instance().startTicking(Modifier.FAST);
+        });
+    }
+}

--- a/HolubLife/src/com/holub/ui/GridMenuGenerator.java
+++ b/HolubLife/src/com/holub/ui/GridMenuGenerator.java
@@ -1,0 +1,23 @@
+package com.holub.ui;
+
+import com.holub.life.Universe;
+
+public class GridMenuGenerator implements MenuGenerator{
+    public void generate(Object requester){
+        MenuSite.addLine(requester, "Grid", "Clear", e -> {
+            Universe.instance().clear();
+        });
+
+        MenuSite.addLine(requester, "Grid", "Load", e -> {
+            Universe.instance().doLoad();
+        });
+
+        MenuSite.addLine(requester, "Grid", "Store", e -> {
+            Universe.instance().doStore();
+        });
+
+        MenuSite.addLine(requester, "Grid", "Exit", e -> {
+            System.exit(0);
+        });
+    }
+}

--- a/HolubLife/src/com/holub/ui/MenuBuilder.java
+++ b/HolubLife/src/com/holub/ui/MenuBuilder.java
@@ -1,0 +1,10 @@
+package com.holub.ui;
+
+public class MenuBuilder{
+    public static void generate(Object requester){
+        MenuGenerator[] menus = {new GoMenuGenerator(), new GridMenuGenerator()};
+        for(MenuGenerator menu : menus){
+            menu.generate(requester);
+        }
+    }
+}

--- a/HolubLife/src/com/holub/ui/MenuGenerator.java
+++ b/HolubLife/src/com/holub/ui/MenuGenerator.java
@@ -1,52 +1,5 @@
 package com.holub.ui;
 
-import com.holub.life.Clock;
-import com.holub.life.Universe;
-import com.holub.constant.Modifier;
-
-public class MenuGenerator {
-
-    public static void generate() {
-        gridMenuGenerate(new Object());
-        goMenuGenerate(new Object());
-    }
-
-    private static void gridMenuGenerate(Object requester) {
-        MenuSite.addLine(requester, "Grid", "Clear", e -> {
-            Universe.instance().clear();
-        });
-
-        MenuSite.addLine(requester, "Grid", "Load", e -> {
-            Universe.instance().doLoad();
-        });
-
-        MenuSite.addLine(requester, "Grid", "Store", e -> {
-            Universe.instance().doStore();
-        });
-
-        MenuSite.addLine(requester, "Grid", "Exit", e -> {
-            System.exit(0);
-        });
-    }
-
-    private static void goMenuGenerate(Object requester) {
-        MenuSite.addLine(requester, "Go", "Tick", e -> {
-            Clock.instance().tick();
-        });
-        MenuSite.addLine(requester, "Go", "Hart", e -> {
-            Clock.instance().stop();
-        });
-        MenuSite.addLine(requester, "Go", "Agonizing", e -> {
-            Clock.instance().startTicking(Modifier.AGONIZING);
-        });
-        MenuSite.addLine(requester, "Go", "Slow", e -> {
-            Clock.instance().startTicking(Modifier.SLOW);
-        });
-        MenuSite.addLine(requester, "Go", "Medium", e -> {
-            Clock.instance().startTicking(Modifier.MEDIUM);
-        });
-        MenuSite.addLine(requester, "Go", "Fast", e -> {
-            Clock.instance().startTicking(Modifier.FAST);
-        });
-    }
+public interface MenuGenerator {
+    public void generate(Object requester);
 }


### PR DESCRIPTION
 다양한 테마에서의 동시 작업이 이루어질 때, 기존의 설계에서는 MenuGenerator에서의 동시 수정이 일어나야 하는 충돌이 발생하는 것을 방지하기 위해, MenuGenerator를 인터페이스로 수정 후, 각 메뉴에 대한 Generator 클래스를 선언하여 충돌을 방지할 것을 제안합니다.
  MenuBuilder 클래스에서 모든 메뉴 제너레이터들을 부름으로써, 테마가 추가될 때는 수정이 생길 수 있지만, 각 테마에서의 수정은 다른 클래스에 영향을 끼치지 않을 것으로 기대됩니다.